### PR TITLE
Added convenience method request.sse? to detect if client requested SSE

### DIFF
--- a/example/config.ru
+++ b/example/config.ru
@@ -15,9 +15,17 @@ class TimeServer < Sinatra::Base
   include Sinatra::SSE
   
   get '/' do
-    sse_stream do |out|
-      EM.add_periodic_timer(1) do 
-        out.push :event => "timer", :data => Time.now.to_s
+    if request.sse?
+      sse_stream do |out|
+        EM.add_periodic_timer(1) do
+          out.push :event => "timer", :data => Time.now.to_s
+        end
+      end
+    else
+      stream(:keep_open) do |out|
+        EM.add_periodic_timer(1) do
+          out << "#{Time.now.to_s}\n"
+        end
       end
     end
   end

--- a/lib/sinatra/sse.rb
+++ b/lib/sinatra/sse.rb
@@ -81,3 +81,12 @@ module Sinatra::SSE
     end
   end
 end
+
+module Sinatra
+  class Request
+    # Convenience method for detecting if client requested SSE
+    def sse?
+      env['HTTP_ACCEPT'] == 'text/event-stream'
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds sse? convenience method for detecting whether client has requested SSE stream. This allows more readable syntax when creating endpoints that support multiple protocols. E.g.

```
get '/' do                                                                  
  if request.websocket?                                                     
    ... web socket handling...                                              
  elsif request.sse?                                                        
    ... SSE handling ...                                                    
  else                                                                      
    ... chunked data ...                                                    
  end                                                                       
end                                                                         
```
