### PR TITLE
Add an error block callback

### DIFF
--- a/lib/sinatra/sse.rb
+++ b/lib/sinatra/sse.rb
@@ -47,7 +47,7 @@ module Sinatra::SSE
       @out.close
     end
     
-    # set a callback block.
+    # set a callback block for errors
     def errback(&block)
       @errback = Proc.new
     end


### PR DESCRIPTION
I needed this when using with [em-hiredis](https://github.com/mloughran/em-hiredis). I had to call `redis.close_connection` when the sinatra-sse client disconnects, else the redis client instances doesn't free its connection and you end up with many redis idle clients.
